### PR TITLE
Feat/add mqtt prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR) # Policy CMP0079.
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR) # Policy CMP0079 & FetchContent_MakeAvailable.
 project(mqtt_client)
 
 ## Compile as C++17
@@ -22,8 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(PahoMqttCpp REQUIRED)
 set(PahoMqttCpp_LIBRARIES PahoMqttCpp::paho-mqttpp3)
 
-# Filesystem
-# This adds support for std::filesystem in GCC < 9, which is required to support ROS Melodic.
+## This adds support for std::filesystem in GCC < 9, which is required to support ROS Melodic.
 include(cmake/modules/filesystem.cmake)
 
 ## Uncomment this if the package has a setup.py. This macro ensures
@@ -159,7 +158,7 @@ add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EX
 ## Specify libraries to link a library or executable target against
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
-  ${PahoMqttCpp_LIBRARIES}
+  PahoMqttCpp::paho-mqttpp3
   ghc::filesystem
 )
 

--- a/cmake/modules/filesystem.cmake
+++ b/cmake/modules/filesystem.cmake
@@ -52,7 +52,7 @@ set(GHC_FILESYSTEM_TEST_CODE [[
 
 
 # Try to compile a simple filesystem program without any linker flags
-INCLUDE(CheckCXXSourceCompiles)
+include(CheckCXXSourceCompiles)
 list(APPEND CMAKE_REQUIRED_INCLUDES "${filesystem_SOURCE_DIR}/include")
 check_cxx_source_compiles("${GHC_FILESYSTEM_TEST_CODE}" GHC_FILESYSTEM_NO_LINK_NEEDED)
 

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
 
   <name>mqtt_client</name>
   <version>1.1.0</version>
@@ -57,7 +57,8 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>message_generation</depend>
   <depend>nodelet</depend>
-  <depend>paho-mqtt-cpp</depend>
+  <!-- This dependency isn't available in ros Melodic. -->
+  <depend condition="$ROS_DISTRO == noetic">paho-mqtt-cpp</depend>
   <depend>roscpp</depend>
   <depend>rosfmt</depend>
   <depend>std_msgs</depend>


### PR DESCRIPTION
Adds support for specifying a common MQTT topic prefix across all the MQTT topics. This will allow for a per-system configuration to be used for each instance of the MQTT client.