### PR TITLE
add json support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,14 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
+  json_msgs
+  json_transport
   message_generation
   nodelet
   roscpp
+  rosfmt
   std_msgs
   topic_tools
-  rosfmt
 )
 
 ## System dependencies are found with CMake's conventions
@@ -111,9 +113,12 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS
+    json_msgs
+    json_transport
     message_runtime
     nodelet
     roscpp
+    rosfmt
     std_msgs
     topic_tools
   DEPENDS PahoMqttCpp

--- a/package.xml
+++ b/package.xml
@@ -55,6 +55,8 @@
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  <depend>json_msgs</depend>
+  <depend>json_transport</depend>
   <depend>message_generation</depend>
   <depend>nodelet</depend>
   <!-- This dependency isn't available in ros Melodic. -->


### PR DESCRIPTION
Adds support for json_msgs::Json types through a primitive MQTT topic. This is useful for sending parsed JSON msgs to/from a ROS robot over MQTT to communicate with a REST API for controlling a robot.