### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package mqtt_client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.2.1 (2023-02-16)
+------------------
+* Merge pull request #6 from oxin-ros/feat/add-support-for-utf8-decoding
+  - Adds support for bistream types based on utf-8 encoding of MQTT message payload.
+* Contributors: David B.
+
 1.2.0 (2023-02-15)
 ------------------
 * Merge pull request #1 from oxin-ros/feat/aws-tls-support

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="3">
 
   <name>mqtt_client</name>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <description>Provides a nodelet that enables connected ROS-based devices or robots to exchange ROS messages via an MQTT broker using the MQTT protocol.</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->


### PR DESCRIPTION
1.2.1 (2023-02-16)
------------------
* Merge pull request #6 from oxin-ros/feat/add-support-for-utf8-decoding
  - Adds support for bistream types based on utf-8 encoding of MQTT message payload.
* Contributors: David B.