### PR TITLE
Feat/ubuntu 18.04 support

### DIFF
--- a/mqtt_client/CMakeLists.txt
+++ b/mqtt_client/CMakeLists.txt
@@ -100,19 +100,37 @@ elseif(${ROS_VERSION} EQUAL 1)
 
   # System dependencies.
   include(FetchContent)
-  FetchContent_Declare(PahoMqttCpp
-    GIT_REPOSITORY https://github.com/eclipse/paho.mqtt.cpp
-    GIT_TAG v1.4.1
-  )
-  FetchContent_MakeAvailable(PahoMqttCpp)
-  set(PahoMqttCpp_LIBRARIES PahoMqttCpp::paho-mqttpp3)
 
-  FetchContent_Declare(fmt
-    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-    GIT_TAG 11.0.2
-  )
-  FetchContent_MakeAvailable(fmt)
-  set(fmt_LIBRARIES fmt::fmt)
+  find_package(PahoMqttCpp QUIET)
+  if(PahoMqttCpp_FOUND)
+    set(PahoMqttCpp_LIBRARIES PahoMqttCpp::paho-mqttpp3)
+  else()
+    FetchContent_Declare(PahoMqttCpp
+      GIT_REPOSITORY https://github.com/eclipse/paho.mqtt.cpp
+      GIT_TAG v1.4.1
+    )
+    FetchContent_MakeAvailable(PahoMqttCpp)
+    set(PahoMqttCpp_LIBRARIES PahoMqttCpp::paho-mqttpp3)
+  endif()
+
+  find_package(fmt QUIET)
+  if(fmt_FOUND)
+    set(fmt_LIBRARIES fmt::fmt)
+  else()
+    FetchContent_Declare(fmt
+      GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+      GIT_TAG 10.2.1
+    )
+    FetchContent_MakeAvailable(fmt)
+    set(fmt_LIBRARIES fmt::fmt)
+  endif()
+
+  FetchContent_Declare(
+    utf8cpp
+    GIT_REPOSITORY https://github.com/nemtrif/utfcpp.git
+    GIT_TAG        v3.2.4)
+  FetchContent_MakeAvailable(utf8cpp)
+  set(utf8cpp_LIBRARIES utf8::cpp)
 
   ## Uncomment this if the package has a setup.py. This macro ensures
   ## modules and global scripts declared therein get installed
@@ -250,8 +268,9 @@ elseif(${ROS_VERSION} EQUAL 1)
   ## Specify libraries to link a library or executable target against
   target_link_libraries(${PROJECT_NAME}
     ${catkin_LIBRARIES}
-    ${PahoMqttC_LIBRARY}
-    ${PahoMqttCpp_LIBRARY}
+    ${fmt_LIBRARIES}
+    ${PahoMqttCpp_LIBRARIES}
+    ${utf8cpp_LIBRARIES}
   )
 
   #############

--- a/mqtt_client/CMakeLists.txt
+++ b/mqtt_client/CMakeLists.txt
@@ -98,9 +98,10 @@ elseif(${ROS_VERSION} EQUAL 1)
   )
 
   ## System dependencies are found with CMake's conventions
-  find_package(PahoMqttCpp REQUIRED)
-  set(PahoMqttCpp_LIBRARIES PahoMqttCpp::paho-mqttpp3)
-
+  # Paho MQTT C++ apt package doesn't include CMake config
+  # find_package(PahoMqttCpp REQUIRED)
+  find_library(PahoMqttC_LIBRARY libpaho-mqtt3as.so.1 REQUIRED)
+  find_library(PahoMqttCpp_LIBRARY libpaho-mqttpp3.so.1 REQUIRED)
 
   ## Uncomment this if the package has a setup.py. This macro ensures
   ## modules and global scripts declared therein get installed
@@ -236,7 +237,8 @@ elseif(${ROS_VERSION} EQUAL 1)
   ## Specify libraries to link a library or executable target against
   target_link_libraries(${PROJECT_NAME}
     ${catkin_LIBRARIES}
-    ${PahoMqttCpp_LIBRARIES}
+    ${PahoMqttC_LIBRARY}
+    ${PahoMqttCpp_LIBRARY}
   )
 
   #############

--- a/mqtt_client/CMakeLists.txt
+++ b/mqtt_client/CMakeLists.txt
@@ -195,7 +195,8 @@ elseif(${ROS_VERSION} EQUAL 1)
       roscpp
       std_msgs
       topic_tools
-    DEPENDS PahoMqttCpp
+    # TODO: investigate why this doesn't work.
+    #DEPENDS PahoMqttCpp
   )
 
   ###########

--- a/mqtt_client/CMakeLists.txt
+++ b/mqtt_client/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.12.0 FATAL_ERROR)
+# While FetchContent only requires CMake 3.11, the convenience function
+# `FetchContent_MakeAvailable` was introduced in CMake 3.14
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 project(mqtt_client)
 
 find_package(ros_environment REQUIRED QUIET)
@@ -96,15 +98,21 @@ elseif(${ROS_VERSION} EQUAL 1)
     topic_tools
   )
 
-  ## System dependencies are found with CMake's conventions
-  # Paho MQTT C++ apt package doesn't include CMake config
-  # find_package(PahoMqttCpp REQUIRED)
-  find_library(PahoMqttC_LIBRARY libpaho-mqtt3as.so.1 REQUIRED)
-  find_library(PahoMqttCpp_LIBRARY libpaho-mqttpp3.so.1 REQUIRED)
+  # System dependencies.
+  include(FetchContent)
+  FetchContent_Declare(PahoMqttCpp
+    GIT_REPOSITORY https://github.com/eclipse/paho.mqtt.cpp
+    GIT_TAG v1.4.1
+  )
+  FetchContent_MakeAvailable(PahoMqttCpp)
+  set(PahoMqttCpp_LIBRARIES PahoMqttCpp::paho-mqttpp3)
 
-  find_package(fmt REQUIRED)
+  FetchContent_Declare(fmt
+    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+    GIT_TAG 11.0.2
+  )
+  FetchContent_MakeAvailable(fmt)
   set(fmt_LIBRARIES fmt::fmt)
-
 
   ## Uncomment this if the package has a setup.py. This macro ensures
   ## modules and global scripts declared therein get installed
@@ -198,7 +206,6 @@ elseif(${ROS_VERSION} EQUAL 1)
       roscpp
       std_msgs
       topic_tools
-    # TODO: investigate why this doesn't work.
     DEPENDS
       fmt
       PahoMqttCpp

--- a/mqtt_client/include/mqtt_client/MqttClient.h
+++ b/mqtt_client/include/mqtt_client/MqttClient.h
@@ -27,7 +27,7 @@ SOFTWARE.
 
 #pragma once
 
-#include <filesystem>
+#include "boost/filesystem.hpp"
 #include <map>
 #include <memory>
 #include <string>
@@ -166,9 +166,9 @@ class MqttClient : public nodelet::Nodelet,
    *
    * @param   path_string  (relative) path as string
    *
-   * @return  std::filesystem::path  path variable
+   * @return  boost::filesystem::path  path variable
    */
-  std::filesystem::path resolvePath(const std::string& path_string);
+  boost::filesystem::path resolvePath(const std::string& path_string);
 
   /**
    * @brief Initializes broker connection and subscriptions.
@@ -336,7 +336,7 @@ class MqttClient : public nodelet::Nodelet,
     std::string pass;  ///< password
     struct {
       bool enabled;  ///< whether to connect via SSL/TLS
-      std::filesystem::path
+      boost::filesystem::path
         ca_certificate;  ///< public CA certificate trusted by client
     } tls;               ///< SSL/TLS-related variables
   };
@@ -349,7 +349,7 @@ class MqttClient : public nodelet::Nodelet,
     struct {
       bool enabled;                     ///< whether client buffer is enabled
       int size;                         ///< client buffer size
-      std::filesystem::path directory;  ///< client buffer directory
+      boost::filesystem::path directory;  ///< client buffer directory
     } buffer;                           ///< client buffer-related variables
     struct {
       std::string topic;         ///< last-will topic
@@ -361,8 +361,8 @@ class MqttClient : public nodelet::Nodelet,
     double keep_alive_interval;  ///< keep-alive interval
     int max_inflight;            ///< maximum number of inflight messages
     struct {
-      std::filesystem::path certificate;    ///< client certificate
-      std::filesystem::path key;            ///< client private keyfile
+      boost::filesystem::path certificate;    ///< client certificate
+      boost::filesystem::path key;            ///< client private keyfile
       std::string password;                 ///< decryption password for private key
       int version;                          ///< TLS version (https://github.com/eclipse/paho.mqtt.cpp/blob/master/src/mqtt/ssl_options.h#L305)
       bool verify;                          ///< Verify the client should conduct

--- a/mqtt_client/package.xml
+++ b/mqtt_client/package.xml
@@ -33,7 +33,8 @@
   <!-- ROS1 -->
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
   <depend condition="$ROS_VERSION == 1">nodelet</depend>
-  <depend condition="$ROS_VERSION == 1">paho-mqtt-cpp</depend>
+  <!-- NOTE: The paho-mqtt-cpp package doesn't exist in ROS melodic. -->
+  <!-- <depend condition="$ROS_VERSION == 1">paho-mqtt-cpp</depend> -->
   <depend condition="$ROS_VERSION == 1">roscpp</depend>
   <depend condition="$ROS_VERSION == 1">rosfmt</depend>
   <depend condition="$ROS_VERSION == 1">topic_tools</depend>

--- a/mqtt_client/package.xml
+++ b/mqtt_client/package.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='utf8'?>
 <package format="3">
 
   <name>mqtt_client</name>
-  <version>2.3.0</version>
+  <version>3.0.0</version>
   <description>Node that enables connected ROS-based devices or robots to exchange ROS messages via an MQTT broker using the MQTT protocol.</description>
 
   <maintainer email="lennart.reiher@rwth-aachen.de">Lennart Reiher</maintainer>
@@ -22,7 +22,7 @@
   <depend>ros_environment</depend>
   <depend>std_msgs</depend>
 
-  <!-- ROS2 -->
+  
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
   <depend condition="$ROS_VERSION == 2">libpaho-mqtt-dev</depend>
   <depend condition="$ROS_VERSION == 2">libpaho-mqttpp-dev</depend>
@@ -30,11 +30,11 @@
   <depend condition="$ROS_VERSION == 2">rclcpp_components</depend>
   <depend condition="$ROS_VERSION == 2">rcpputils</depend>
 
-  <!-- ROS1 -->
+  
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
   <depend condition="$ROS_VERSION == 1">nodelet</depend>
-  <!-- NOTE: The paho-mqtt-cpp package doesn't exist in ROS melodic. -->
-  <!-- <depend condition="$ROS_VERSION == 1">paho-mqtt-cpp</depend> -->
+  
+  
   <depend condition="$ROS_VERSION == 1">roscpp</depend>
   <depend condition="$ROS_VERSION == 1">topic_tools</depend>
 

--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -362,21 +362,21 @@ bool MqttClient::loadParameter(const std::string& key, std::string& value,
 }
 
 
-std::filesystem::path MqttClient::resolvePath(const std::string& path_string) {
+boost::filesystem::path MqttClient::resolvePath(const std::string& path_string) {
 
-  std::filesystem::path path(path_string);
+  boost::filesystem::path path(path_string);
   if (path_string.empty()) return path;
   if (!path.has_root_path()) {
     std::string ros_home;
     ros::get_environment_variable(ros_home, "ROS_HOME");
     if (ros_home.empty())
-      ros_home = std::string(std::filesystem::current_path());
-    path = std::filesystem::path(ros_home);
+      ros_home = boost::filesystem::current_path().string();
+    path = boost::filesystem::path(ros_home);
     path.append(path_string);
   }
-  if (!std::filesystem::exists(path))
+  if (!boost::filesystem::exists(path))
     NODELET_WARN("Requested path '%s' does not exist",
-                 std::string(path).c_str());
+                 path.string().c_str());
   return path;
 }
 
@@ -432,11 +432,11 @@ void MqttClient::setupClient() {
   // SSL/TLS
   if (broker_config_.tls.enabled) {
     mqtt::ssl_options ssl;
-    ssl.set_trust_store(broker_config_.tls.ca_certificate);
+    ssl.set_trust_store(broker_config_.tls.ca_certificate.string());
     if (!client_config_.tls.certificate.empty() &&
         !client_config_.tls.key.empty()) {
-      ssl.set_key_store(client_config_.tls.certificate);
-      ssl.set_private_key(client_config_.tls.key);
+      ssl.set_key_store(client_config_.tls.certificate.string());
+      ssl.set_private_key(client_config_.tls.key.string());
       if (!client_config_.tls.password.empty())
         ssl.set_private_key_password(client_config_.tls.password);
     }
@@ -454,7 +454,7 @@ void MqttClient::setupClient() {
     if (client_config_.buffer.enabled) {
       client_ = std::shared_ptr<mqtt::async_client>(new mqtt::async_client(
         uri, client_config_.id, client_config_.buffer.size,
-        client_config_.buffer.directory));
+        client_config_.buffer.directory.string()));
     } else {
       client_ = std::shared_ptr<mqtt::async_client>(
         new mqtt::async_client(uri, client_config_.id));

--- a/mqtt_client/src/MqttClient.ros2.cpp
+++ b/mqtt_client/src/MqttClient.ros2.cpp
@@ -251,6 +251,10 @@ bool primitiveRosMessageToString(
     std_msgs::msg::Float64 msg;
     deserializeRosMessage(*serialized_msg, msg);
     primitive = std::to_string(msg.data);
+  } else if (msg_type == "std_msgs/msg/UInt8MultiArray") {
+    std_msgs::msg::UInt8MultiArray msg;
+    deserializeRosMessage(*serialized_msg, msg);
+    primitive = std::string(msg.data.begin(), msg.data.end());
   } else {
     found_primitive = false;
   }
@@ -953,7 +957,7 @@ void MqttClient::ros2mqtt(
 
     // resolve ROS messages to primitive strings if possible
     std::string payload;
-    bool found_primitive =
+    const bool found_primitive =
       primitiveRosMessageToString(serialized_msg, ros_msg_type.name, payload);
     if (found_primitive) {
       payload_buffer = std::vector<uint8_t>(payload.begin(), payload.end());
@@ -1176,6 +1180,19 @@ void MqttClient::mqtt2primitive(mqtt::const_message_ptr mqtt_msg) {
       }
     } catch (const std::invalid_argument& ex) {
     } catch (const std::out_of_range& ex) {
+    }
+  }
+
+  // check for non-UTF8 string.
+  if (!found_primitive) {
+    const bool is_valid_utf8 = utf8::is_valid(str_msg);
+    if (!is_valid_utf8) {
+      std_msgs::msg::UInt8MultiArray msg;
+      msg.data = std::vector<uint8_t>(str_msg.begin(), str_msg.end());
+      serializeRosMessage(msg, serialized_msg);
+
+      ros_msg_type = "std_msgs/msg/UInt8MultiArray";
+      found_primitive = true;
     }
   }
 

--- a/mqtt_client_interfaces/package.xml
+++ b/mqtt_client_interfaces/package.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='utf8'?>
 <package format="3">
 
   <name>mqtt_client_interfaces</name>
-  <version>2.3.0</version>
+  <version>3.0.0</version>
   <description>Message and service definitions for mqtt_client</description>
 
   <maintainer email="lennart.reiher@rwth-aachen.de">Lennart Reiher</maintainer>
@@ -16,13 +16,13 @@
 
   <depend>ros_environment</depend>
 
-  <!-- ROS2 -->
+  
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
   <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
   <depend condition="$ROS_VERSION == 2">std_msgs</depend>
   <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
 
-  <!-- ROS1 -->
+  
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
   <depend condition="$ROS_VERSION == 1">message_generation</depend>
   <depend condition="$ROS_VERSION == 1">std_msgs</depend>


### PR DESCRIPTION
Adds support for Ubuntu 18.04, namely:
- Use boost::filesystem instead of std::filesystem
- Explicitly search for Paho MQTT C & C++ library files instead of relying on `PahoMqttCpp` target.